### PR TITLE
Explicitly request XML from parldata API

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -27,7 +27,7 @@ EODATA
 @termdata = CSV.parse(termdates, headers: true, header_converters: :symbol)
 
 def noko_q(endpoint, h)
-  result = RestClient.get (@API_URL % endpoint), params: h
+  result = RestClient.get (@API_URL % endpoint), params: h, accept: :xml
   doc = Nokogiri::XML(result)
   doc.remove_namespaces!
   entries = doc.xpath('resource/resource')


### PR DESCRIPTION
There has been a change recently which meant that the parldata API was
returning JSON by default, rather than the XML that we are using.

This change adds an explicit `Accept` header and sets it to XML so we
get back the correct data type.

This is the same change as https://github.com/everypolitician-scrapers/montenegro-parldata/pull/1